### PR TITLE
Keep one version during package maintenance

### DIFF
--- a/.github/workflows/package-maintenance.yaml
+++ b/.github/workflows/package-maintenance.yaml
@@ -16,5 +16,5 @@ jobs:
         with: 
           package-type: container
           package-name: build
-          min-versions-to-keep: 0
+          min-versions-to-keep: 1
           


### PR DESCRIPTION
GitHub complains that you can not delete the last version of a package and should delete the package instead. The docs of the action say:
  > To delete all versions set this as 0.